### PR TITLE
Update ScoreSimilarity.py

### DIFF
--- a/metric/ScoreSimilarity.py
+++ b/metric/ScoreSimilarity.py
@@ -440,14 +440,14 @@ def scoreSimilarity(estScore, gtScore):
             return noteObj.tie.type if noteObj.tie is not None else ''
 
         def referClef(noteObj): # added
-            return noteObj.getContextByClass('Clef').name if noteObj.getContextByClass('Clef') is not None else ''
+            return noteObj.getContextByClass('Clef', getElementMethod=ElementSearch.ALL).name if noteObj.getContextByClass('Clef', getElementMethod=ElementSearch.ALL) is not None else ''
 
         def referTimeSig(noteObj): # added
-            return noteObj.getContextByClass('TimeSignature').numerator / noteObj.getContextByClass('TimeSignature').denominator \
-                    if noteObj.getContextByClass('TimeSignature') is not None else ''
+            return noteObj.getContextByClass('TimeSignature', getElementMethod=ElementSearch.ALL).numerator / noteObj.getContextByClass('TimeSignature', getElementMethod=ElementSearch.ALL).denominator \
+                    if noteObj.getContextByClass('TimeSignature', getElementMethod=ElementSearch.ALL) is not None else ''
 
         def referKeySig(noteObj): # added
-            keyObj = (noteObj.getContextByClass('Key') or noteObj.getContextByClass('KeySignature'))
+            keyObj = (noteObj.getContextByClass('Key', getElementMethod=ElementSearch.ALL) or noteObj.getContextByClass('KeySignature', getElementMethod=ElementSearch.ALL))
             return keyObj.sharps if keyObj else 0
 
         def referVoice(noteObj): # added


### PR DESCRIPTION
The current method of finding a music21.Note's Clef, Time Signature, and Key Signature does not work for some initial notes that were extracted from a Chord object, whereby the .getContextByClass() method returns None. Adding the getElementMethod=ElementSearch.ALL argument would fix such errors. For example, the attached MusicXML files has 22% error on Clef, Key Signature and Time Signature, but visually it is clear that they have the same Clef, Key Signature and Time Signature, and therefore should have 0% error instead. This fix would resolve such errors. 

[ss_bug_scores.zip](https://github.com/NZX23/ScoreTransformer/files/13801379/ss_bug_scores.zip)
